### PR TITLE
Fix build failure: defer Resend instantiation to request time

### DIFF
--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -1,6 +1,5 @@
 import { Resend } from 'resend'
 
-const resend = new Resend(process.env.RESEND_API_KEY)
 const OWNER_EMAIL = process.env.ORDER_NOTIFICATION_EMAIL ?? 'hardy_patrick@yahoo.ca'
 
 interface OrderPayload {
@@ -48,6 +47,8 @@ export async function POST(request: Request) {
   const order = body as OrderPayload
   const orderNumber = generateOrderNumber()
   const summary = orderSummary(order)
+
+  const resend = new Resend(process.env.RESEND_API_KEY)
 
   await resend.emails.send({
     from: 'Sai Oua <orders@saioua.com>',


### PR DESCRIPTION
## Problem

`new Resend(process.env.RESEND_API_KEY)` was called at module level in `app/api/order/route.ts`. During `npm run build`, Next.js evaluates the module to collect page data, which throws immediately when `RESEND_API_KEY` is not set in the build environment.

## Fix

Move `new Resend(...)` inside the `POST` handler so it only runs at request time, not at build time.

## Test plan

- [x] `npm run build` completes successfully without `RESEND_API_KEY` set
- [x] `npm test` — 76 tests pass, 0 failures

Fixes build regression introduced in #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)