### PR TITLE
Fix 500 on order submission; add validation and API tests

### DIFF
--- a/__tests__/api-order.test.ts
+++ b/__tests__/api-order.test.ts
@@ -1,0 +1,117 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for POST /api/order (TC-A01–07)
+ * Resend is mocked so no real emails are sent.
+ */
+
+const mockSend = jest.fn()
+jest.mock('resend', () => ({
+  Resend: jest.fn().mockImplementation(() => ({
+    emails: { send: mockSend },
+  })),
+}))
+
+import { POST } from '@/app/api/order/route'
+
+const VALID_BODY = {
+  quantity: 2,
+  name: 'John Doe',
+  address: '123 Fake St',
+  city: 'Boca Raton',
+  province: 'FL',
+  postal: '90210',
+  country: 'US',
+  email: 'fakeassname1933@gmail.com',
+  phone: '9058675309',
+}
+
+function makeRequest(body: object) {
+  return new Request('http://localhost/api/order', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+beforeEach(() => {
+  mockSend.mockReset()
+  process.env.RESEND_API_KEY = 're_test_key'
+})
+
+afterEach(() => {
+  delete process.env.RESEND_API_KEY
+})
+
+// TC-A01
+it('TC-A01 valid payload returns 200 with orderNumber', async () => {
+  mockSend.mockResolvedValue({ data: { id: 'email-id' }, error: null })
+  const res = await POST(makeRequest(VALID_BODY))
+  expect(res.status).toBe(200)
+  const json = await res.json()
+  expect(json.success).toBe(true)
+  expect(json.orderNumber).toMatch(/^ORD-[A-Z0-9]+-[A-F0-9]{4}$/)
+})
+
+// TC-A02
+it('TC-A02 missing email returns 400', async () => {
+  const { email: _email, ...body } = VALID_BODY
+  const res = await POST(makeRequest(body))
+  expect(res.status).toBe(400)
+})
+
+// TC-A03
+it('TC-A03 missing name returns 400', async () => {
+  const { name: _name, ...body } = VALID_BODY
+  const res = await POST(makeRequest(body))
+  expect(res.status).toBe(400)
+})
+
+// TC-A04
+it('TC-A04 missing quantity returns 400', async () => {
+  const { quantity: _quantity, ...body } = VALID_BODY
+  const res = await POST(makeRequest(body))
+  expect(res.status).toBe(400)
+})
+
+// TC-A04 (extended) — quantity out of range
+it('TC-A04 quantity 0 returns 400', async () => {
+  const res = await POST(makeRequest({ ...VALID_BODY, quantity: 0 }))
+  expect(res.status).toBe(400)
+})
+
+it('TC-A04 quantity 11 returns 400', async () => {
+  const res = await POST(makeRequest({ ...VALID_BODY, quantity: 11 }))
+  expect(res.status).toBe(400)
+})
+
+// TC-A04 (extended) — invalid email format
+it('TC-A04 malformed email returns 400', async () => {
+  const res = await POST(makeRequest({ ...VALID_BODY, email: 'not-an-email' }))
+  expect(res.status).toBe(400)
+})
+
+// TC-A05 — both emails are sent
+it('TC-A05 sends confirmation to customer and notification to owner', async () => {
+  mockSend.mockResolvedValue({ data: { id: 'email-id' }, error: null })
+  await POST(makeRequest(VALID_BODY))
+  expect(mockSend).toHaveBeenCalledTimes(2)
+  expect(mockSend.mock.calls[0][0].to).toBe(VALID_BODY.email)
+  expect(mockSend.mock.calls[1][0].to).toBe('hardy_patrick@yahoo.ca')
+})
+
+// TC-A06 — Resend error on first send returns 500
+it('TC-A06 Resend error on customer email returns 500', async () => {
+  mockSend.mockResolvedValue({ data: null, error: { message: 'domain not verified' } })
+  const res = await POST(makeRequest(VALID_BODY))
+  expect(res.status).toBe(500)
+})
+
+// TC-A06 (extended) — missing API key returns 500
+it('TC-A06 missing RESEND_API_KEY returns 500', async () => {
+  delete process.env.RESEND_API_KEY
+  const res = await POST(makeRequest(VALID_BODY))
+  expect(res.status).toBe(500)
+  const json = await res.json()
+  expect(json.error).toMatch(/not configured/i)
+})

--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -2,6 +2,8 @@ import { Resend } from 'resend'
 
 const OWNER_EMAIL = process.env.ORDER_NOTIFICATION_EMAIL ?? 'hardy_patrick@yahoo.ca'
 
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 interface OrderPayload {
   quantity: number
   name: string
@@ -14,9 +16,18 @@ interface OrderPayload {
   phone: string
 }
 
-const REQUIRED: (keyof OrderPayload)[] = [
-  'quantity', 'name', 'address', 'city', 'province', 'postal', 'country', 'email', 'phone',
-]
+function validateOrder(body: Partial<OrderPayload>): string | null {
+  const fields: (keyof OrderPayload)[] = [
+    'name', 'address', 'city', 'province', 'postal', 'country', 'email', 'phone',
+  ]
+  for (const f of fields) {
+    if (!body[f] || String(body[f]).trim() === '') return `Missing field: ${f}`
+  }
+  const qty = Number(body.quantity)
+  if (!Number.isInteger(qty) || qty < 1 || qty > 10) return 'quantity must be an integer between 1 and 10'
+  if (!EMAIL_RE.test(body.email!)) return 'Invalid email address'
+  return null
+}
 
 function generateOrderNumber(): string {
   const ts = Date.now().toString(36).toUpperCase()
@@ -39,30 +50,40 @@ Phone    : ${order.phone}
 export async function POST(request: Request) {
   const body = await request.json() as Partial<OrderPayload>
 
-  const missing = REQUIRED.filter((k) => !body[k])
-  if (missing.length > 0) {
-    return Response.json({ error: `Missing fields: ${missing.join(', ')}` }, { status: 400 })
+  const validationError = validateOrder(body)
+  if (validationError) {
+    return Response.json({ error: validationError }, { status: 400 })
   }
 
-  const order = body as OrderPayload
+  const order = { ...body, quantity: Number(body.quantity) } as OrderPayload
   const orderNumber = generateOrderNumber()
   const summary = orderSummary(order)
 
+  if (!process.env.RESEND_API_KEY) {
+    return Response.json({ error: 'Email service not configured' }, { status: 500 })
+  }
+
   const resend = new Resend(process.env.RESEND_API_KEY)
 
-  await resend.emails.send({
+  const { error: customerError } = await resend.emails.send({
     from: 'Sai Oua <orders@saioua.com>',
     to: order.email,
     subject: `Order Confirmation — ${orderNumber}`,
     text: `Thank you for your order!\n\nOrder Number: ${orderNumber}\n\n${summary}\n\nWe will be in touch soon.`,
   })
+  if (customerError) {
+    return Response.json({ error: 'Failed to send confirmation email' }, { status: 500 })
+  }
 
-  await resend.emails.send({
+  const { error: ownerError } = await resend.emails.send({
     from: 'Sai Oua <orders@saioua.com>',
     to: OWNER_EMAIL,
     subject: `New Order — ${orderNumber}`,
     text: `A new order has been placed.\n\nOrder Number: ${orderNumber}\n\n${summary}`,
   })
+  if (ownerError) {
+    return Response.json({ error: 'Failed to send owner notification' }, { status: 500 })
+  }
 
   return Response.json({ success: true, orderNumber })
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,2 @@
 import '@testing-library/jest-dom'
+


### PR DESCRIPTION
## Problem

A valid order payload was returning a 500. Root cause: `new Resend(process.env.RESEND_API_KEY)` throws synchronously when `RESEND_API_KEY` is undefined, and the POST handler had no error handling — so any Resend error (missing key, unverified domain, network failure) became an unhandled exception.

A secondary issue: the Resend SDK returns `{ data, error }` rather than throwing on API errors, but the previous code never checked for `error`.

## Changes

**`app/api/order/route.ts`**
- Early guard: returns `500 "Email service not configured"` if `RESEND_API_KEY` is not set
- Checks `{ error }` on both `resend.emails.send()` calls and returns 500 with a message on failure
- Added `validateOrder()` with server-side checks:
  - All string fields must be non-empty
  - `quantity` must be an integer between 1 and 10
  - `email` must match a basic format regex

**`__tests__/api-order.test.ts`** (new)
- 10 unit tests covering TC-A01–06 from the test plan
- Resend is fully mocked — no real emails sent
- Runs in `node` environment so Web API globals are available

**`jest.setup.ts`** — removed a broken polyfill attempt (not needed)

## Test plan

- [x] `npm test` — 86 tests pass, 0 failures (76 existing + 10 new API tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)