### PR TITLE
Inject env vars at runtime; add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   web:
     build: .
+    env_file: .env
     ports:
       - "3000:3000"
     restart: unless-stopped


### PR DESCRIPTION
## Changes

- `docker-compose.yml` — added `env_file: .env` so secrets are injected at container start rather than baked into the image layers
- `.dockerignore` — added to exclude `.env*`, `node_modules`, and `.next` from the build context, keeping secrets out of the image entirely

## Why

Previously `COPY . .` in the Dockerfile copied `.env` into the image, meaning the API key was stored in a build layer. With this change the image contains no secrets — they are only present in the running container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)