### PR TITLE
Fix sender domain; surface Resend error details

### DIFF
--- a/app/api/order/route.ts
+++ b/app/api/order/route.ts
@@ -65,24 +65,26 @@ export async function POST(request: Request) {
 
   const resend = new Resend(process.env.RESEND_API_KEY)
 
+  const FROM = process.env.RESEND_FROM_EMAIL ?? 'onboarding@resend.dev'
+
   const { error: customerError } = await resend.emails.send({
-    from: 'Sai Oua <orders@saioua.com>',
+    from: `Sai Oua <${FROM}>`,
     to: order.email,
     subject: `Order Confirmation — ${orderNumber}`,
     text: `Thank you for your order!\n\nOrder Number: ${orderNumber}\n\n${summary}\n\nWe will be in touch soon.`,
   })
   if (customerError) {
-    return Response.json({ error: 'Failed to send confirmation email' }, { status: 500 })
+    return Response.json({ error: 'Failed to send confirmation email', detail: customerError }, { status: 500 })
   }
 
   const { error: ownerError } = await resend.emails.send({
-    from: 'Sai Oua <orders@saioua.com>',
+    from: `Sai Oua <${FROM}>`,
     to: OWNER_EMAIL,
     subject: `New Order — ${orderNumber}`,
     text: `A new order has been placed.\n\nOrder Number: ${orderNumber}\n\n${summary}`,
   })
   if (ownerError) {
-    return Response.json({ error: 'Failed to send owner notification' }, { status: 500 })
+    return Response.json({ error: 'Failed to send owner notification', detail: ownerError }, { status: 500 })
   }
 
   return Response.json({ success: true, orderNumber })


### PR DESCRIPTION
## Problem

`orders@saioua.com` is not a verified sender domain in the Resend account, so every send was rejected.

## Fix

- Default `from` address to `onboarding@resend.dev` — Resend's built-in test sender that works without domain verification
- `RESEND_FROM_EMAIL` env var can override this when a real domain is verified (e.g. `orders@saioua.com`)
- 500 responses now include a `detail` field with the raw Resend error object, making future failures easier to diagnose

## Test plan

- [x] `npm test` — 86 tests pass, 0 failures
- [ ] Manual: rebuild and retest order submission end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)